### PR TITLE
InMemoryStorage Return `null` when filtering if there are no entities 

### DIFF
--- a/src/main/java/org/apereo/openlrs/storage/inmemory/InMemoryStorage.java
+++ b/src/main/java/org/apereo/openlrs/storage/inmemory/InMemoryStorage.java
@@ -59,7 +59,7 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 	public OpenLRSEntity findById(String id) {
 		return store.get(id);
 	}
-	
+
 	@Override
 	public List<OpenLRSEntity> findAll() {
 		return new ArrayList<OpenLRSEntity>(store.values());
@@ -83,11 +83,11 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 		log.warn("InMemoryStorage does not support filters. Return all.");
 		return new PageImpl<OpenLRSEntity>(new ArrayList<OpenLRSEntity>(store.values()));
 	}
-	
+
 	@Override
 	public Page<OpenLRSEntity> findByUser(String userId, Pageable pageable) {
 		Collection<OpenLRSEntity> values = store.values();
-		if (values != null && !values.isEmpty()) {			
+		if (values != null && !values.isEmpty()) {
 			List<OpenLRSEntity> filtered = null;
 			for (OpenLRSEntity entity : values) {
 				if (entity.toJSON().contains(userId)) {
@@ -98,7 +98,9 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 					filtered.add(entity);
 				}
 			}
-			return new PageImpl<OpenLRSEntity>(filtered);
+			if (filtered != null) {
+				return new PageImpl<OpenLRSEntity>(filtered);
+			}
 		}
 		return null;
 	}
@@ -106,7 +108,7 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 	@Override
 	public Page<OpenLRSEntity> findByContext(String context, Pageable pageable) {
 		Collection<OpenLRSEntity> values = store.values();
-		if (values != null && !values.isEmpty()) {			
+		if (values != null && !values.isEmpty()) {
 			List<OpenLRSEntity> filtered = null;
 			for (OpenLRSEntity entity : values) {
 				if (entity.toJSON().contains(context)) {
@@ -117,7 +119,9 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 					filtered.add(entity);
 				}
 			}
-			return new PageImpl<OpenLRSEntity>(filtered);
+			if (filtered != null) {
+				return new PageImpl<OpenLRSEntity>(filtered);
+			}
 		}
 		return null;
 	}
@@ -125,7 +129,7 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 	@Override
 	public Page<OpenLRSEntity> findByContextAndUser(String context, String userId, Pageable pageable) {
 		Collection<OpenLRSEntity> values = store.values();
-		if (values != null && !values.isEmpty()) {			
+		if (values != null && !values.isEmpty()) {
 			List<OpenLRSEntity> filtered = null;
 			for (OpenLRSEntity entity : values) {
 				if (entity.toJSON().contains(context) && entity.toJSON().contains(userId)) {
@@ -136,7 +140,9 @@ public class InMemoryStorage implements TierOneStorage<OpenLRSEntity>, TierTwoSt
 					filtered.add(entity);
 				}
 			}
-			return new PageImpl<OpenLRSEntity>(filtered);
+			if (filtered != null) {
+				return new PageImpl<OpenLRSEntity>(filtered);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
I ran into this during the workshop when filtering statements by context resulted in an empty resultset:
```
2015-05-31 15:27:04.715 DEBUG 42932 --- [nio-8091-exec-3] o.a.o.c.xapi.XAPIExceptionHandlerAdvice  : Unexpected XAPI exception [refId: bZaT8sgD]: {}

java.lang.IllegalArgumentException: Content must not be null!
	at org.springframework.util.Assert.notNull(Assert.java:112)
	at org.springframework.data.domain.Chunk.<init>(Chunk.java:47)
	at org.springframework.data.domain.PageImpl.<init>(PageImpl.java:41)
	at org.springframework.data.domain.PageImpl.<init>(PageImpl.java:52)
	at org.apereo.openlrs.storage.inmemory.InMemoryStorage.findByContext(InMemoryStorage.java:121)
	at org.apereo.openlrs.services.NormalizedEventService.getByContext(NormalizedEventService.java:36)
```

I think this PR addresses that