### PR TITLE
TLCALIPER-23 - Enable authZ for Caliper requests

### DIFF
--- a/src/main/java/org/apereo/openlrs/Application.java
+++ b/src/main/java/org/apereo/openlrs/Application.java
@@ -90,6 +90,9 @@ public class Application {
 		List<String> urls = new ArrayList<String>(2);
 		urls.add("/xAPI/statements");
 		urls.add("/xAPI/statements/*");
+		// All Caliper URLs except "/caliper/about"
+		urls.add("/caliper");
+		urls.add("/caliper/");
 		urls.add("/api/*");
 		registrationBean.setUrlPatterns(urls);
 		registrationBean.setOrder(2);


### PR DESCRIPTION
Enabling authZ for all Caliper requests except "/caliper/about".

I plan to include this in the merge of the "caliper" branch to the "development" one soon.

Please merge this PR at your earliest convenience.

Thanks!